### PR TITLE
Dynamic radix selection

### DIFF
--- a/MDParolaFontEditor.html
+++ b/MDParolaFontEditor.html
@@ -604,7 +604,7 @@
 				}
 				var char_cols = char.slice(1, char.length - 1);
 				var decoded_cols = char_cols.map(function (value) {
-					value = parseInt(value, 10).toString(2).padStart(8, '0');
+					value = parseInt(value).toString(2).padStart(8, '0');
 					return value.split('').reverse();
 				});
 				return decoded_cols;


### PR DESCRIPTION
By removing the radix argument from parseInt it is also able to parse hexadecimal values, e.g. `0x1f`, instead of just decimal.

As described on https://www.w3schools.com/jsref/jsref_parseint.asp "If radix is omitted, JavaScript assumes radix 10. If the value begins with "0x", JavaScript assumes radix 16."

This enables parsing of hexadecimal values, provided by some other tools, like https://github.com/vasco65/md_max72xx-font-designer/tree/master/fonts.